### PR TITLE
fix List view initExpanded warning by upgrading patternfly-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
     "lodash": "^4.17.10",
-    "patternfly-react": "^2.19.1",
+    "patternfly-react": "^2.29.12",
     "prop-types": "^15.6.0",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",


### PR DESCRIPTION
the problem: the first list view item does not initially opens as expected with a warning seen.

while trying to align to Foreman 1.20.1 dependencies versions,
we used patternfly-react version 2.19.1
it seem that there was a fix to the `initExpanded` prop which is only available from version 2.29.12.
found no other regression while bumping its version, 
the first list view item initially opens as expected with no warning.