### PR TITLE
import isEqual directly from lodash

### DIFF
--- a/webpack/ForemanInventoryUpload/Components/Terminal/Terminal.js
+++ b/webpack/ForemanInventoryUpload/Components/Terminal/Terminal.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Grid, Spinner } from 'patternfly-react';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import './terminal.scss';
 import { isTerminalScrolledDown } from './TerminalHelper';
 


### PR DESCRIPTION
on the packaging PR, koji was complaining it can't find the `lodash/isEqual` module,
changing the import fixed it.